### PR TITLE
Consistent `Datatractor` branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 </div>
 
-A repository containing the [LinkML](https://linkml.io/linkml/)-based schemas backing the registry of extractors at [datatractor yard](https://github.com/datatractor/yard/) and powering the reference implementation of the extractor framework at [datatractor beam](https://github.com/datatractor/beam/).
+A repository containing the [LinkML](https://linkml.io/linkml/)-based schemas backing the registry of extractors at [Datatractor Yard](https://github.com/datatractor/yard/) and powering the reference implementation of the extractor framework at [Datatractor Beam](https://github.com/datatractor/beam/).
 
 This repository is a continuation of the MaRDA WG7 on Automated [Metadata Extractors](https://www.marda-alliance.org/working-group/wg7-automated-metadata-extractors/).
 
@@ -49,12 +49,12 @@ gen-python schemas/filetype.yaml >> filetype.py
 gen-pydantic schemas/extractor.yaml >> extractor.py
 ```
 
-The generated files can be used in downstream codes such as in the [validation function](https://github.com/datatractor/beam/blob/main/tasks.py#L33) of [datatractor beam](https://github.com/datatractor/beam).
+The generated files can be used in downstream codes such as in the [validation function](https://github.com/datatractor/beam/blob/main/tasks.py#L33) of [Datatractor Beam](https://github.com/datatractor/beam).
 
 ## Contributing
 
 Contributions are welcome. We pledge to follow the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 
-If you wish to contribute a new `FileType` or a new `Extractor` to the Registry, please open a pull request at the [datatractor yard repo](https://github.com/datatractor/yard).
+If you wish to contribute a new `FileType` or a new `Extractor` to the Registry, please open a pull request at the [Datatractor Yard repo](https://github.com/datatractor/yard).
 
-If you have any suggestions, technical queries, or a feature request related to the schemas, please do not hesitate to open an issue in this repository. For general questions related to the datatractor project, please use the [datatractor schema discussion board](https://github.com/datatractor/schema/discussions).
+If you have any suggestions, technical queries, or a feature request related to the schemas, please do not hesitate to open an issue in this repository. For general questions related to the Datatractor project, please use the [Datatractor discussion board](https://github.com/orgs/datatractor/discussions).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,8 +19,8 @@ version = "main"
 
 # -- Project information -----------------------------------------------------
 
-project = "datatractor schema"
-copyright = "2022 - 2024, datatractor team"
+project = "Datatractor Schema"
+copyright = "2022 - 2024, Datatractor team"
 author = "Matthew Evans, Peter Kraus"
 release = version
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ version = "main"
 # -- Project information -----------------------------------------------------
 
 project = "Datatractor Schema"
-copyright = "2022 - 2024, Datatractor team"
+copyright = "2022 - 2024, Datatractor Team"
 author = "Matthew Evans, Peter Kraus"
 release = version
 
@@ -73,7 +73,7 @@ html_context = {
     "github_user": "datatractor",
     "github_repo": "schema",
     "github_version": version,
-    "conf_py_path": "/docs/source/"
+    "conf_py_path": "/docs/source/",
 }
 html_logo = "https://avatars.githubusercontent.com/u/166528759"
 html_favicon = "https://datatractor.github.io/schema/main/_images/166528759-32x32.png"

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -9,7 +9,7 @@ Contributions to this project are welcome. We pledge to follow the `Contributor 
 
 If you have any suggestions, technical queries, or a feature request related to the schemas, please do not hesitate to `open an issue <https://github.com/datatractor/schema/issues>`_ on |schemarepo|_.
 
-For general questions related to the datatractor project, please use the `discussion board in the schema repo on GitHub <https://github.com/datatractor/schema/discussions>`_.
+For general questions related to the Datatractor project, please use the `discussion board on the Datatractor page on GitHub <https://github.com/orgs/datatractor/discussions>`_.
 
 Contributors
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-datatractor schema
-==================
+Datatractor Schema: Schemas for Metadata Extractors
+===================================================
 
 A repository at |schemarepo|_, containing the |LinkML|_-based schemas backing the |yardrepo|_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Datatractor Schema: Schemas for Metadata Extractors
 
 A repository at |schemarepo|_, containing the |LinkML|_-based schemas backing the |yardrepo|_.
 
-The schemas implemented here are machine-actionable. They are used by the `Registry <https://marda-registry.fly.dev/>`_ to validate entries; a reference implementation demonstrating their pracical use is shown in the |beamrepo|_.
+The schemas implemented here are machine-actionable. They are used by the `Registry <https://yard.datatractor.org/>`_ to validate entries; a reference implementation demonstrating their pracical use is shown in the |beamrepo|_.
 
 .. note::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,4 +1,4 @@
-Usage of datatractor schema
+Usage of Datatractor Schema
 ===========================
 
 Usage example
@@ -8,7 +8,7 @@ This repository is intended to be used as a |git submodule|_ to be cloned and us
 
 .. figure:: images/registry.screenshot.PNG
    :target: https://github.com/datatractor/yard
-   :alt: A screenshot of the datatractor yard showing "schemas" as a link to another repository.
+   :alt: A screenshot of the Datatractor Yard showing "schemas" as a link to another repository.
 
    A screenshot of |yard|. Note that ``schemas`` is a ``git submodule``, pointing to the Schema repository at a certain commit (here: |c03a732|_, corresponding to the 1.0 release).
 
@@ -52,7 +52,7 @@ The generated files are intended to be used in downstream codes such as in the `
 
 .. _git submodule: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 
-.. |yard| replace:: datatractor yard
+.. |yard| replace:: Datatractor Yard
 
 .. _yard: https://github.com/datatractor/yard
 

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -12,7 +12,7 @@ imports:
     - linkml:types
 default_range: string
 description: >-
-    This file describes the generic slots used by models in the datatractor schema.
+    This file describes the generic slots used by models in the Datatractor Schema.
 
 
 classes:
@@ -77,7 +77,7 @@ classes:
         attributes:
             id:
                 description: >-
-                    A reference to the registered datatractor `FileType->id` for this file
+                    A reference to the registered Datatractor `FileType->id` for this file
                     type.
             description:
                 description: Free-text description of caveats or instructions specific
@@ -213,7 +213,7 @@ slots:
         slot_uri: schema_org:identifier
         required: true
         description: >-
-            A unique identifier for the entry within the datatractor yard
+            A unique identifier for the entry within the Datatractor Yard
             namespace, this should be a shorthand label rather than
             a UUID. Only lower-case alphanumeric and dash ("-") characters
             are permitted.

--- a/schemas/extractor.yaml
+++ b/schemas/extractor.yaml
@@ -1,5 +1,5 @@
 ---
-title: datatractor schema
+title: Datatractor Schema
 name: extractor
 version: 1.0
 id: https://datatractor.github.io/schema/main/datatractor_schema/
@@ -17,7 +17,7 @@ imports:
     - filetype
 default_range: string
 description: >-
-    This file describes the `Extractor` model from the datatractor schema.
+    This file describes the `Extractor` model from the Datatractor Schema.
 
 
 classes:

--- a/schemas/filetype.yaml
+++ b/schemas/filetype.yaml
@@ -14,7 +14,7 @@ imports:
     - base
 default_range: string
 description: >-
-    This file describes the `FileType` model from the datatractor schema.
+    This file describes the `FileType` model from the Datatractor Schema.
 
 
 classes:


### PR DESCRIPTION
Let's make `Datatractor` a noun, i.e. capitalised, along with the Yard, Schema, and Beam.

Also, the `Datatractor` org has a discussion board, so linking to that instead.