### PR TITLE
`Extractor.Usage.scope` defaults to `meta+data`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-linkml >= 1.5.2, < 1.6.2
-linkml-runtime != 1.6.1
+linkml >= 1.6.3
+linkml-runtime > 1.6.1
 pre-commit ~= 2.20

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -165,7 +165,7 @@ classes:
                       The templated parameters which can be requested from the user
                       are [described by the `UsageTemplate` class](UsageTemplate.md).
             scope:
-                required: false
+                ifabsent: UsageScope(meta+data)
                 range: UsageScope
                 description: >-
                     Specification of extraction scope.


### PR DESCRIPTION
Closes #8. Requires a version bump in `linkml`, tested with `==1.6.3`, `~=1.7.0` and `==1.8.5` (latest).