### PR TITLE
Playing around with possible output schema definitions

### DIFF
--- a/examples/Extractor-example.yaml
+++ b/examples/Extractor-example.yaml
@@ -49,5 +49,13 @@ supported_filetypes:
           Example Extractor can parse example-filetype once in a blue moon.
       template:
           input_type: example
+supported_output_schemas:
+    - schema:
+          description: >-
+              The fields in the output example extractor follows the JSONSchema linked
+              below.
+          href: >-
+              https://example.com/schema.json
+
 license:
     uri: https://example.com

--- a/schemas/base.yaml
+++ b/schemas/base.yaml
@@ -77,7 +77,8 @@ classes:
         attributes:
             id:
                 description: >-
-                    A reference to the registered Datatractor `FileType->id` for this file
+                    A reference to the registered Datatractor `FileType->id` for this
+                    file
                     type.
             description:
                 description: Free-text description of caveats or instructions specific
@@ -132,6 +133,34 @@ classes:
                     The `FileType` of the `output_path`, for `Extractors` supporting
                     multiple output `FileTypes`. Defaults to the `FileType->id` for
                     each supported output file type.
+
+    SchemaDescription:
+        description: >-
+            A human-readable schema definition, with a reference to a machine-actionable
+            schema definition if available.
+        attributes:
+            description:
+                description: >-
+                    A human-readable description of the schema and its usage.
+            href:
+                description: >-
+                    A URL or URI for the schema definition.
+
+    OutputSchema:
+        description: >-
+            A human-readable specification of the schema that the output of an `Extractor`.
+        attributes:
+            supported_filetypes:
+                range: SupportedFileType
+                multivalued: true
+                required: false
+                description: >-
+                    The file types that this schema can be used for; defaults to all
+                    if not provided.
+            schema:
+                required: true
+                range: SchemaDescription
+
 
     Usage:
         description: >-

--- a/schemas/extractor.yaml
+++ b/schemas/extractor.yaml
@@ -59,6 +59,17 @@ classes:
                     These should match `FileTypes` present in the registry. They can
                     be specified on extractor execution using the templates described
                     in the `Extractor->Usage->command` slot, [see the `Usage` class](Usage.md).
+            supported_output_schemas:
+                multivalued: true
+                required: false
+                range: OutputSchema
+                description: >-
+                    A description of the schema that a extractor output can follow;
+                    this may be scoped per file type, or a global schema that works
+                    for all file types.
+                    This should refer to any machine-actionable schema definition,
+                    for example, JSONSchema, XMLSchema, or it may refer to a
+                    self-describing format such as JSON-LD or RDF.
             source_repository:
                 description: >-
                     A URL or URI for a source code repository associated with this


### PR DESCRIPTION
It would be good to introduce a "light touch" schema definition, so that extractors that have valid schemas can at least describe and point to them to aid findability, even if these are not fully machine-actionable. This PR is a placeholder to start thinking about what that would look like.